### PR TITLE
Add api http handlers

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,7 +1,20 @@
 package main
 
-import "fmt"
+import (
+	"log"
+	"net/http"
+
+	"github.com/rinha-de-backend/rinha-2025-trio-arc/internal/handlers"
+)
 
 func main() {
-	fmt.Println("hey :)")
+	http.HandleFunc("/payments", handlers.HandlePayments)
+	http.HandleFunc("/payments-summary", handlers.HandlePaymentsSummary)
+
+	port := ":8080"
+	log.Printf("Server listening on %s", port)
+
+	if err := http.ListenAndServe(port, nil); err != nil {
+		log.Fatalf("Error starting server: %v", err)
+	}
 }

--- a/internal/handlers/payment.go
+++ b/internal/handlers/payment.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rinha-de-backend/rinha-2025-trio-arc/internal/models"
+)
+
+func HandlePayments(w http.ResponseWriter, r *http.Request) {
+	var request models.PaymentRequest
+
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&request); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if request.CorrelationID == "" || request.Amount <= 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// payment := models.NewPayment(request.CorrelationID, request.Amount)
+	// serialized, err := json.Marshal(payment)
+	// if err != nil {
+	// 	w.WriteHeader(http.StatusInternalServerError)
+	// 	return
+	// }
+
+	// push serialized message to Redis
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/handlers/summary.go
+++ b/internal/handlers/summary.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rinha-de-backend/rinha-2025-trio-arc/internal/models"
+)
+
+func HandlePaymentsSummary(w http.ResponseWriter, r *http.Request) {
+	from := r.URL.Query().Get("from")
+	to := r.URL.Query().Get("to")
+
+	request, err := models.NewSummaryRequest(from, to)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	filter := &models.SummaryFilter{
+		From: request.From,
+		To:   request.To,
+	}
+
+	summary, err := models.GetStats(filter)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(summary)
+}


### PR DESCRIPTION
This PR adds two endpoints required by the application:

* `POST /payments`: Receives payment requests with mandatory `correlationId` and `amount`. The response is just a HTTP status code.

* `GET /payments-summary`: Returns a summary of processed payments with optional `from` and `to` ISO UTC timestamps. Response includes totals for `default` and `fallback` processors.
